### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-ton-linux-arm64-shared.yml
+++ b/.github/workflows/build-ton-linux-arm64-shared.yml
@@ -1,7 +1,8 @@
 name: Ubuntu TON build (shared, arm64)
 
 on: [push,workflow_dispatch,workflow_call]
-
+permissions:
+  contents: read
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/yalan2ny/sha1-ton/security/code-scanning/3](https://github.com/yalan2ny/sha1-ton/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's steps, it primarily involves checking out the repository, caching dependencies, and running tests. These actions only require `contents: read` permissions. No write permissions are necessary unless additional functionality is added in the future.

The `permissions` block should be added at the top level of the workflow, immediately after the `name` or `on` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
